### PR TITLE
feat: upload multiple state versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,38 @@ Some resources will contain multiple instances using a string index key. Some re
 Requires terraform to run tests. Use `make test`
 
 `make fmt`
+
+## Uploading Multiple State Versions
+
+To simulate a busy workspace with many state versions, use the included Ruby script `scripts/push_multiple_states.rb`.
+
+This script will:
+1. Generate a new random state file using `statefaker`.
+2. Patch the `serial` and `lineage` to match your target workspace.
+3. Push the state file to TFC.
+4. Repeat for N iterations.
+
+### Usage
+
+1. **Build statefaker** (if you haven't already):
+   ```bash
+   go build -o statefaker ./cmd/statefaker
+   ```
+
+2. **Run the script**:
+   Point the script to the directory containing your Terraform configuration (where `terraform init` was run).
+
+   ```bash
+   # Push 5 new state versions to the workspace configured in ../my-infra
+   ruby scripts/push_multiple_states.rb --cwd ../my-infra --iterations 5
+   ```
+
+   **Options:**
+   - `--cwd DIR`: Directory containing Terraform config (default: current dir).
+   - `--iterations N`: Number of state versions to push (default: 5).
+   - `--resources N`: Number of resources to generate per state (default: 1000).
+   - `--outputs N`: Number of outputs to generate per state (default: 0).
+   - `--bin PATH`: Path to statefaker binary (default: searches PATH/cwd).
+   - `--verbose`: Run verbosely.
+
+   **Note:** The script automatically fetches the current `serial` and `lineage` from the remote workspace before pushing. Ensure you are authenticated with Terraform Cloud/Enterprise.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24.0
 
 toolchain go1.24.7
 
-require (
-	github.com/go-faker/faker/v4 v4.7.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
-)
+require github.com/go-faker/faker/v4 v4.7.0
+
+require golang.org/x/text v0.29.0 // indirect

--- a/pkg/statefaker/customfaker.go
+++ b/pkg/statefaker/customfaker.go
@@ -8,31 +8,53 @@ import (
 	"reflect"
 )
 
-func GenerateAttributes(resourceType string) (json.RawMessage, error) {
+func GenerateAttributes(resourceType, mode string) (json.RawMessage, error) {
 	// Generate realistic resource attributes based on resource type
 	var generator func() map[string]any
 
-	switch resourceType {
-	case "aws_s3_bucket":
-		generator = generateS3BucketAttributes
-	case "aws_iam_user":
-		generator = generateIAMUserAttributes
-	case "aws_instance":
-		generator = generateEC2InstanceAttributes
-	case "aws_lambda_function":
-		generator = generateLambdaFunctionAttributes
-	case "aws_db_instance":
-		generator = generateRDSInstanceAttributes
-	case "aws_api_gateway_rest_api":
-		generator = generateAPIGatewayRestAPIAttributes
-	default:
-		// Fallback for types without specific generators
-		generator = func() map[string]any {
-			// Generate minimal valid attributes based on ID only
-			// Most resources have an ID, and extra unknown attributes can cause errors
-			name := generateResourceName()
-			return map[string]any{
-				"id": name,
+	// If mode is 'data', we should ideally have specific generators for data sources
+	// For now, if it's a data source, fallback to minimal attributes to avoid
+	// "unsupported attribute" errors when managed resource attributes don't match data source schema.
+	if mode == "data" {
+		// Exception: Some data sources are safe or we want to test them specifically
+		// But generally, safer to fallback for data sources unless we implement specific logic
+		switch resourceType {
+		// aws_s3_bucket data source is quite compatible with our generator, except maybe tags?
+		// Let's be conservative and fallback for all data sources for now to fix the immediate issue.
+		default:
+			generator = func() map[string]any {
+				name := generateResourceName()
+				return map[string]any{
+					"id": name,
+					// Most data sources support 'id', or we can add 'arn' if we know it's safe
+					// But even 'arn' is not universal (e.g. aws_db_instance data source has db_instance_arn)
+				}
+			}
+		}
+	} else {
+		// Managed resources
+		switch resourceType {
+		case "aws_s3_bucket":
+			generator = generateS3BucketAttributes
+		case "aws_iam_user":
+			generator = generateIAMUserAttributes
+		case "aws_instance":
+			generator = generateEC2InstanceAttributes
+		case "aws_lambda_function":
+			generator = generateLambdaFunctionAttributes
+		case "aws_db_instance":
+			generator = generateRDSInstanceAttributes
+		case "aws_api_gateway_rest_api":
+			generator = generateAPIGatewayRestAPIAttributes
+		default:
+			// Fallback for types without specific generators
+			generator = func() map[string]any {
+				// Generate minimal valid attributes based on ID only
+				// Most resources have an ID, and extra unknown attributes can cause errors
+				name := generateResourceName()
+				return map[string]any{
+					"id": name,
+				}
 			}
 		}
 	}

--- a/pkg/statefaker/customfaker.go
+++ b/pkg/statefaker/customfaker.go
@@ -8,17 +8,35 @@ import (
 	"reflect"
 )
 
-func tfattributesProvider(v reflect.Value) (any, error) {
-	// Generate realistic resource attributes based on common AWS resource types
-	attributeGenerators := []func() map[string]any{
-		generateS3BucketAttributes,
-		generateIAMUserAttributes,
-		generateEC2InstanceAttributes,
-		generateLambdaFunctionAttributes,
-		generateRDSInstanceAttributes,
+func GenerateAttributes(resourceType string) (json.RawMessage, error) {
+	// Generate realistic resource attributes based on resource type
+	var generator func() map[string]any
+
+	switch resourceType {
+	case "aws_s3_bucket":
+		generator = generateS3BucketAttributes
+	case "aws_iam_user":
+		generator = generateIAMUserAttributes
+	case "aws_instance":
+		generator = generateEC2InstanceAttributes
+	case "aws_lambda_function":
+		generator = generateLambdaFunctionAttributes
+	case "aws_db_instance":
+		generator = generateRDSInstanceAttributes
+	case "aws_api_gateway_rest_api":
+		generator = generateAPIGatewayRestAPIAttributes
+	default:
+		// Fallback for types without specific generators
+		generator = func() map[string]any {
+			// Generate minimal valid attributes based on ID only
+			// Most resources have an ID, and extra unknown attributes can cause errors
+			name := generateResourceName()
+			return map[string]any{
+				"id": name,
+			}
+		}
 	}
 
-	generator := attributeGenerators[rand.IntN(len(attributeGenerators))]
 	resourceAttributes := generator()
 
 	b, err := json.Marshal(resourceAttributes)
@@ -30,23 +48,8 @@ func tfattributesProvider(v reflect.Value) (any, error) {
 }
 
 func tfidentityProvider(v reflect.Value) (any, error) {
-	// Most of the time, generate an empty identity
-	if rand.IntN(5) > 2 {
-		return json.RawMessage(""), nil
-	}
-
-	// Generate a simple identity structure
-	identity := map[string]any{
-		"arn":        generateARN("iam", fmt.Sprintf("user/%s", generateUserName())),
-		"account_id": generateAWSAccountID(),
-		"region":     generateAWSRegion(),
-	}
-
-	b, err := json.Marshal(identity)
-	if err != nil {
-		return nil, err
-	}
-	return json.RawMessage(b), nil
+	// Always return nil for identity as most resources don't support it
+	return nil, nil
 }
 
 func tfprivateProvider(v reflect.Value) (any, error) {

--- a/pkg/statefaker/random.go
+++ b/pkg/statefaker/random.go
@@ -344,10 +344,9 @@ func generateSecurityGroupOutput(output *OutputV4) {
 func generateAPIGatewayRestAPIAttributes() map[string]any {
 	apiID := fmt.Sprintf("%s-api", faker.UUIDDigit()[:10])
 	return map[string]any{
-		"id":           apiID,
-		"name":         generateResourceName(),
-		"description":  faker.Sentence(),
-		"created_date": faker.Date(),
+		"id":          apiID,
+		"name":        generateResourceName(),
+		"description": faker.Sentence(),
 		"tags": map[string]string{
 			"Environment": "production",
 			"Service":     "api-gateway",
@@ -446,7 +445,7 @@ func generateRDSInstanceAttributes() map[string]any {
 		"engine":                 []string{"mysql", "postgres", "mariadb"}[rand.IntN(3)],
 		"engine_version":         "14.1",
 		"instance_class":         "db.t3.micro",
-		"name":                   instanceID,
+		"db_name":                instanceID, // Was "name", now deprecated/removed in v5
 		"username":               faker.Username(),
 		"password":               faker.Password(),
 		"port":                   5432,

--- a/pkg/statefaker/random.go
+++ b/pkg/statefaker/random.go
@@ -11,7 +11,6 @@ import (
 // Register custom faker providers for our specific fields. These are all used
 // by the InstanceV4 struct tags.
 func init() {
-	_ = faker.AddProvider("tfattributes", tfattributesProvider)
 	_ = faker.AddProvider("tfidentity", tfidentityProvider)
 	_ = faker.AddProvider("tfprivate", tfprivateProvider)
 	_ = faker.AddProvider("tfdependencies", tfdependenciesProvider)
@@ -65,7 +64,7 @@ func generateUserName() string {
 func generateResourceType() string {
 	resourceTypes := []string{
 		"aws_s3_bucket", "aws_iam_user", "aws_iam_role", "aws_lambda_function",
-		"aws_ec2_instance", "aws_rds_instance", "aws_dynamodb_table", "aws_vpc",
+		"aws_instance", "aws_db_instance", "aws_dynamodb_table", "aws_vpc",
 		"aws_security_group", "aws_route53_zone", "aws_cloudfront_distribution",
 		"aws_ecs_cluster", "aws_eks_cluster", "aws_api_gateway_rest_api",
 	}
@@ -183,7 +182,6 @@ func generateUserMapOutput(output *OutputV4) {
 			"access_key_id":               generateAccessKeyID(),
 			"encrypted_secret_access_key": faker.Password(),
 			"pgp_key_name": map[string]string{
-				"name":              "aws-pgp-v0-2020-07-08.pgp.base64",
 				"public_key_base64": faker.Password(), // Simplified for example
 			},
 		}
@@ -207,7 +205,6 @@ func generateUserMapOutput(output *OutputV4) {
 			"pgp_key_name": []any{
 				"object",
 				map[string]string{
-					"name":              "string",
 					"public_key_base64": "string",
 				},
 			},
@@ -308,7 +305,6 @@ func generateSecurityGroupOutput(output *OutputV4) {
 
 	config := map[string]any{
 		"id":          fmt.Sprintf("sg-%s", faker.UUIDDigit()),
-		"name":        fmt.Sprintf("%s-sg", generateResourceName()),
 		"description": faker.Sentence(),
 		"rules":       rules,
 		"vpc_id":      fmt.Sprintf("vpc-%s", faker.UUIDDigit()),
@@ -318,7 +314,6 @@ func generateSecurityGroupOutput(output *OutputV4) {
 		"object",
 		map[string]any{
 			"id":          "string",
-			"name":        "string",
 			"description": "string",
 			"rules": []any{
 				"list",
@@ -346,38 +341,19 @@ func generateSecurityGroupOutput(output *OutputV4) {
 }
 
 // Attribute generators for different resource types
+func generateAPIGatewayRestAPIAttributes() map[string]any {
+	apiID := fmt.Sprintf("%s-api", faker.UUIDDigit()[:10])
+	return map[string]any{
+		"id": apiID,
+	}
+}
+
 func generateS3BucketAttributes() map[string]any {
 	bucketName := generateS3BucketName()
 	return map[string]any{
-		"id":                          bucketName,
-		"arn":                         generateARN("s3", bucketName),
-		"bucket":                      bucketName,
-		"bucket_domain_name":          fmt.Sprintf("%s.s3.amazonaws.com", bucketName),
-		"bucket_regional_domain_name": fmt.Sprintf("%s.s3.%s.amazonaws.com", bucketName, generateAWSRegion()),
-		"region":                      generateAWSRegion(),
-		"versioning": []map[string]any{
-			{
-				"enabled":    rand.IntN(2) == 1,
-				"mfa_delete": false,
-			},
-		},
-		"server_side_encryption_configuration": []map[string]any{
-			{
-				"rule": []map[string]any{
-					{
-						"apply_server_side_encryption_by_default": []map[string]any{
-							{
-								"sse_algorithm": "AES256",
-							},
-						},
-					},
-				},
-			},
-		},
-		"tags": map[string]string{
-			"Environment": []string{"prod", "staging", "dev"}[rand.IntN(3)],
-			"Team":        []string{"data", "ml", "web", "mobile"}[rand.IntN(4)],
-		},
+		"id":     bucketName,
+		"arn":    generateARN("s3", bucketName),
+		"bucket": bucketName,
 	}
 }
 
@@ -386,14 +362,8 @@ func generateIAMUserAttributes() map[string]any {
 	return map[string]any{
 		"id":                   userName,
 		"arn":                  generateARN("iam", fmt.Sprintf("user/%s", userName)),
-		"name":                 userName,
 		"path":                 "/",
 		"permissions_boundary": nil,
-		"unique_id":            fmt.Sprintf("AIDA%s", faker.UUIDDigit()[:16]),
-		"tags": map[string]string{
-			"Role": []string{"reader", "writer", "admin"}[rand.IntN(3)],
-			"Team": []string{"data", "ml", "security"}[rand.IntN(3)],
-		},
 	}
 }
 
@@ -401,8 +371,6 @@ func generateEC2InstanceAttributes() map[string]any {
 	instanceID := fmt.Sprintf("i-%s", faker.UUIDDigit()[:17])
 	return map[string]any{
 		"id":                     instanceID,
-		"arn":                    generateARN("ec2", fmt.Sprintf("instance/%s", instanceID)),
-		"instance_id":            instanceID,
 		"instance_type":          []string{"t3.micro", "t3.small", "m5.large", "c5.xlarge"}[rand.IntN(4)],
 		"ami":                    fmt.Sprintf("ami-%s", faker.UUIDDigit()[:17]),
 		"availability_zone":      generateAWSRegion() + []string{"a", "b", "c"}[rand.IntN(3)],
@@ -412,11 +380,6 @@ func generateEC2InstanceAttributes() map[string]any {
 		"vpc_security_group_ids": []string{fmt.Sprintf("sg-%s", faker.UUIDDigit()[:17])},
 		"key_name":               faker.Username(),
 		"monitoring":             rand.IntN(2) == 1,
-		"state":                  "running",
-		"tags": map[string]string{
-			"Name":        fmt.Sprintf("%s-instance", generateResourceName()),
-			"Environment": []string{"prod", "staging", "dev"}[rand.IntN(3)],
-		},
 	}
 }
 
@@ -424,7 +387,6 @@ func generateLambdaFunctionAttributes() map[string]any {
 	functionName := fmt.Sprintf("%s-lambda", generateResourceName())
 	return map[string]any{
 		"id":               functionName,
-		"arn":              generateARN("lambda", fmt.Sprintf("function:%s", functionName)),
 		"function_name":    functionName,
 		"role":             generateARN("iam", fmt.Sprintf("role/%s-lambda-role", generateResourceName())),
 		"handler":          "index.handler",
@@ -442,39 +404,13 @@ func generateLambdaFunctionAttributes() map[string]any {
 				},
 			},
 		},
-		"tags": map[string]string{
-			"Environment": []string{"prod", "staging", "dev"}[rand.IntN(3)],
-			"Team":        []string{"backend", "data", "ml"}[rand.IntN(3)],
-		},
 	}
 }
 
 func generateRDSInstanceAttributes() map[string]any {
 	instanceID := fmt.Sprintf("%s-db", generateResourceName())
 	return map[string]any{
-		"id":                      instanceID,
-		"arn":                     generateARN("rds", fmt.Sprintf("db:%s", instanceID)),
-		"identifier":              instanceID,
-		"engine":                  []string{"postgres", "mysql", "mariadb"}[rand.IntN(3)],
-		"engine_version":          []string{"13.7", "14.2", "8.0.28"}[rand.IntN(3)],
-		"instance_class":          []string{"db.t3.micro", "db.t3.small", "db.r5.large"}[rand.IntN(3)],
-		"allocated_storage":       []int{20, 50, 100, 200}[rand.IntN(4)],
-		"storage_type":            "gp2",
-		"db_name":                 faker.Username(),
-		"username":                faker.Username(),
-		"port":                    []int{3306, 5432}[rand.IntN(2)],
-		"endpoint":                fmt.Sprintf("%s.%s.%s.rds.amazonaws.com", instanceID, faker.UUIDDigit()[:10], generateAWSRegion()),
-		"hosted_zone_id":          fmt.Sprintf("Z%s", faker.UUIDDigit()[:13]),
-		"status":                  "available",
-		"multi_az":                rand.IntN(2) == 1,
-		"backup_retention_period": rand.IntN(35) + 1,
-		"backup_window":           "03:00-04:00",
-		"maintenance_window":      "sun:04:00-sun:05:00",
-		"storage_encrypted":       rand.IntN(2) == 1,
-		"tags": map[string]string{
-			"Environment": []string{"prod", "staging", "dev"}[rand.IntN(3)],
-			"Team":        []string{"data", "backend", "analytics"}[rand.IntN(3)],
-		},
+		"id": instanceID,
 	}
 }
 

--- a/pkg/statefaker/random.go
+++ b/pkg/statefaker/random.go
@@ -344,16 +344,31 @@ func generateSecurityGroupOutput(output *OutputV4) {
 func generateAPIGatewayRestAPIAttributes() map[string]any {
 	apiID := fmt.Sprintf("%s-api", faker.UUIDDigit()[:10])
 	return map[string]any{
-		"id": apiID,
+		"id":           apiID,
+		"name":         generateResourceName(),
+		"description":  faker.Sentence(),
+		"created_date": faker.Date(),
+		"tags": map[string]string{
+			"Environment": "production",
+			"Service":     "api-gateway",
+		},
 	}
 }
 
 func generateS3BucketAttributes() map[string]any {
 	bucketName := generateS3BucketName()
 	return map[string]any{
-		"id":     bucketName,
-		"arn":    generateARN("s3", bucketName),
-		"bucket": bucketName,
+		"id":                          bucketName,
+		"arn":                         generateARN("s3", bucketName),
+		"bucket":                      bucketName,
+		"bucket_domain_name":          fmt.Sprintf("%s.s3.amazonaws.com", bucketName),
+		"bucket_regional_domain_name": fmt.Sprintf("%s.s3.%s.amazonaws.com", bucketName, generateAWSRegion()),
+		"hosted_zone_id":              "Z3AQBSTJI090",
+		"region":                      generateAWSRegion(),
+		"tags": map[string]string{
+			"Environment": "production",
+			"Team":        "devops",
+		},
 	}
 }
 
@@ -362,8 +377,13 @@ func generateIAMUserAttributes() map[string]any {
 	return map[string]any{
 		"id":                   userName,
 		"arn":                  generateARN("iam", fmt.Sprintf("user/%s", userName)),
+		"name":                 userName,
 		"path":                 "/",
 		"permissions_boundary": nil,
+		"force_destroy":        false,
+		"tags": map[string]string{
+			"ManagedBy": "terraform",
+		},
 	}
 }
 
@@ -371,6 +391,7 @@ func generateEC2InstanceAttributes() map[string]any {
 	instanceID := fmt.Sprintf("i-%s", faker.UUIDDigit()[:17])
 	return map[string]any{
 		"id":                     instanceID,
+		"arn":                    generateARN("ec2", fmt.Sprintf("instance/%s", instanceID)),
 		"instance_type":          []string{"t3.micro", "t3.small", "m5.large", "c5.xlarge"}[rand.IntN(4)],
 		"ami":                    fmt.Sprintf("ami-%s", faker.UUIDDigit()[:17]),
 		"availability_zone":      generateAWSRegion() + []string{"a", "b", "c"}[rand.IntN(3)],
@@ -380,6 +401,10 @@ func generateEC2InstanceAttributes() map[string]any {
 		"vpc_security_group_ids": []string{fmt.Sprintf("sg-%s", faker.UUIDDigit()[:17])},
 		"key_name":               faker.Username(),
 		"monitoring":             rand.IntN(2) == 1,
+		"tags": map[string]string{
+			"Name":        generateResourceName(),
+			"Environment": "production",
+		},
 	}
 }
 
@@ -387,6 +412,7 @@ func generateLambdaFunctionAttributes() map[string]any {
 	functionName := fmt.Sprintf("%s-lambda", generateResourceName())
 	return map[string]any{
 		"id":               functionName,
+		"arn":              generateARN("lambda", fmt.Sprintf("function:%s", functionName)),
 		"function_name":    functionName,
 		"role":             generateARN("iam", fmt.Sprintf("role/%s-lambda-role", generateResourceName())),
 		"handler":          "index.handler",
@@ -404,13 +430,33 @@ func generateLambdaFunctionAttributes() map[string]any {
 				},
 			},
 		},
+		"tags": map[string]string{
+			"Project": "serverless",
+		},
 	}
 }
 
 func generateRDSInstanceAttributes() map[string]any {
 	instanceID := fmt.Sprintf("%s-db", generateResourceName())
 	return map[string]any{
-		"id": instanceID,
+		"id":                     instanceID,
+		"arn":                    generateARN("rds", fmt.Sprintf("db:%s", instanceID)),
+		"allocated_storage":      rand.IntN(100) + 20,
+		"storage_type":           "gp2",
+		"engine":                 []string{"mysql", "postgres", "mariadb"}[rand.IntN(3)],
+		"engine_version":         "14.1",
+		"instance_class":         "db.t3.micro",
+		"name":                   instanceID,
+		"username":               faker.Username(),
+		"password":               faker.Password(),
+		"port":                   5432,
+		"publicly_accessible":    false,
+		"vpc_security_group_ids": []string{fmt.Sprintf("sg-%s", faker.UUIDDigit()[:17])},
+		"db_subnet_group_name":   fmt.Sprintf("subnet-group-%s", faker.Word()),
+		"tags": map[string]string{
+			"Environment": "production",
+			"Database":    "primary",
+		},
 	}
 }
 

--- a/pkg/statefaker/statefaker.go
+++ b/pkg/statefaker/statefaker.go
@@ -30,11 +30,11 @@ type ResourceV4 struct {
 
 type InstanceV4 struct {
 	IndexKey              string          `json:"index_key,omitempty"`
-	SchemaVersion         int             `json:"schema_version"`
-	Attributes            json.RawMessage `json:"attributes" faker:"tfattributes"`
+	SchemaVersion         int             `json:"schema_version" faker:"oneof: 0"`
+	Attributes            json.RawMessage `json:"attributes"`
 	SensitiveAttributes   []string        `json:"sensitive_attributes" faker:"tfemptystringslice"`
-	IdentitySchemaVersion int             `json:"identity_schema_version" faker:"oneof: 0,1"`
-	Identity              json.RawMessage `json:"identity,omitempty" faker:"tfidentity"`
+	IdentitySchemaVersion int             `json:"identity_schema_version" faker:"-"`
+	Identity              json.RawMessage `json:"identity,omitempty" faker:"-"`
 	Private               string          `json:"private,omitempty" faker:"tfprivate"`
 	Dependencies          []string        `json:"dependencies,omitempty" faker:"tfdependencies"`
 }
@@ -85,6 +85,32 @@ func NewFakeStateV4(opts ...Option) (*StateV4, error) {
 			err := faker.FakeData(&instance)
 			if err != nil {
 				return nil, fmt.Errorf("failed to fake data for managed resource instance: %w", err)
+			}
+
+			// Manually generate attributes based on resource type
+			attrs, err := GenerateAttributes(resourceType)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate attributes: %w", err)
+			}
+			instance.Attributes = attrs
+
+			// Fix schema version for specific resources
+			if mode == "managed" {
+				if resourceType == "aws_cloudfront_distribution" {
+					instance.SchemaVersion = 1
+				} else if resourceType == "aws_db_instance" {
+					instance.SchemaVersion = 2
+				} else if resourceType == "aws_dynamodb_table" {
+					instance.SchemaVersion = 1
+				} else if resourceType == "aws_eks_cluster" {
+					instance.SchemaVersion = 1
+				} else if resourceType == "aws_instance" {
+					instance.SchemaVersion = 2
+				} else if resourceType == "aws_security_group" {
+					instance.SchemaVersion = 1
+				} else if resourceType == "aws_vpc" {
+					instance.SchemaVersion = 1
+				}
 			}
 
 			// Set unique IndexKey for multiple instances

--- a/pkg/statefaker/statefaker.go
+++ b/pkg/statefaker/statefaker.go
@@ -88,7 +88,7 @@ func NewFakeStateV4(opts ...Option) (*StateV4, error) {
 			}
 
 			// Manually generate attributes based on resource type
-			attrs, err := GenerateAttributes(resourceType)
+			attrs, err := GenerateAttributes(resourceType, mode)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate attributes: %w", err)
 			}

--- a/scripts/push_multiple_states.rb
+++ b/scripts/push_multiple_states.rb
@@ -1,0 +1,185 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'open3'
+require 'fileutils'
+require 'optparse'
+
+# Configuration defaults
+options = {
+  cwd: Dir.pwd,
+  iterations: 5,
+  statefaker_bin: nil,
+  resources: 1000,
+  outputs: 0,
+  verbose: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: push_multiple_states.rb [options]"
+
+  opts.on("-c", "--cwd DIR", "Directory containing Terraform config (default: current dir)") do |v|
+    options[:cwd] = v
+  end
+
+  opts.on("-n", "--iterations N", Integer, "Number of state versions to push (default: 5)") do |v|
+    options[:iterations] = v
+  end
+
+  opts.on("-b", "--bin PATH", "Path to statefaker binary (default: searches PATH/cwd)") do |v|
+    options[:statefaker_bin] = v
+  end
+
+  opts.on("-r", "--resources N", Integer, "Number of resources to generate per state (default: 1000)") do |v|
+    options[:resources] = v
+  end
+
+  opts.on("-o", "--outputs N", Integer, "Number of outputs to generate per state (default: 0)") do |v|
+    options[:outputs] = v
+  end
+
+  opts.on("-v", "--verbose", "Run verbosely") do |v|
+    options[:verbose] = v
+  end
+end.parse!
+
+# Helper to find executable in PATH
+def find_executable(name)
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+    exts.each do |ext|
+      exe = File.join(path, "#{name}#{ext}")
+      return exe if File.executable?(exe) && !File.directory?(exe)
+    end
+  end
+  nil
+end
+
+# 1. Locate statefaker binary
+statefaker = options[:statefaker_bin]
+if statefaker.nil?
+  # specific to this repo structure
+  possible_paths = [
+    "./statefaker",
+    "../statefaker",
+    "../../statefaker",
+    File.join(File.dirname(__FILE__), "../statefaker")
+  ]
+  
+  statefaker = possible_paths.find { |p| File.exist?(p) }
+  
+  if statefaker.nil?
+    # Try to find in PATH
+    statefaker = find_executable("statefaker")
+  end
+
+  # If still not found, try to build it if we are in the source repo
+  if statefaker.nil? && File.exist?("go.mod") && File.read("go.mod").include?("module github.com/brandonc/statefaker")
+    puts "Building statefaker..."
+    system("go build -o statefaker ./cmd/statefaker")
+    statefaker = "./statefaker"
+  end
+end
+
+if statefaker.nil? || !File.exist?(statefaker)
+  puts "Error: Could not find 'statefaker' binary."
+  puts "Please build it with `go build -o statefaker ./cmd/statefaker` or provide path with --bin"
+  exit 1
+end
+
+statefaker = File.expand_path(statefaker)
+puts "Using statefaker binary: #{statefaker}" if options[:verbose]
+
+# 2. Get initial state from Terraform
+# We need to run this in the target directory (cwd)
+target_cwd = File.expand_path(options[:cwd])
+unless File.directory?(target_cwd)
+  puts "Error: Target directory #{target_cwd} does not exist."
+  exit 1
+end
+
+puts "Inspecting remote state in #{target_cwd}..."
+stdout, stderr, status = Open3.capture3("terraform", "state", "pull", :chdir => target_cwd)
+
+unless status.success?
+  puts "Error: Failed to pull Terraform state. Ensure you are authenticated and initialized in #{target_cwd}."
+  puts stderr
+  exit 1
+end
+
+begin
+  remote_state = JSON.parse(stdout)
+rescue JSON::ParserError
+  puts "Error: invalid JSON from terraform state pull"
+  exit 1
+end
+
+current_serial = remote_state["serial"]
+lineage = remote_state["lineage"]
+
+if current_serial.nil? || lineage.nil?
+  puts "Error: Could not determine serial or lineage from remote state."
+  exit 1
+end
+
+puts "Current Remote Serial: #{current_serial}"
+puts "Remote Lineage: #{lineage}"
+puts "Plan: Push #{options[:iterations]} new versions starting at serial #{current_serial + 1}"
+
+# 3. Loop and push
+temp_file = File.join(Dir.pwd, "temp_huge.tfstate")
+
+(1..options[:iterations]).each do |i|
+  next_serial = current_serial + i
+  puts "\n--- Iteration #{i}/#{options[:iterations]} (Target Serial: #{next_serial}) ---"
+
+  # Generate
+  # We run statefaker where the binary is, or use absolute path
+  # It writes to temp_file
+  cmd = "#{statefaker} -resources #{options[:resources]} -outputs #{options[:outputs]} > #{temp_file}"
+  puts "Generating state with #{cmd}..." if options[:verbose]
+  
+  unless system(cmd)
+    puts "Error running statefaker generation command"
+    exit 1
+  end
+
+  # Patch
+  puts "Patching serial/lineage..." if options[:verbose]
+  json_data = File.read(temp_file)
+  state = JSON.parse(json_data)
+  
+  # Update critical fields
+  state["version"] = 4
+  state["serial"] = next_serial
+  state["lineage"] = lineage
+  
+  File.write(temp_file, JSON.pretty_generate(state))
+
+  # Push
+  puts "Pushing to remote workspace..."
+  # We must run `terraform state push` inside the directory with the backend config
+  # But the file path must be accessible. `temp_file` is absolute path so it's fine.
+  stdout, stderr, status = Open3.capture3("terraform", "state", "push", temp_file, :chdir => target_cwd)
+
+  if status.success?
+    puts "✅ Successfully pushed serial #{next_serial}"
+  else
+    puts "❌ Failed to push serial #{next_serial}"
+    # Check for stale serial error (race condition)
+    if stderr.include?("stale") || stderr.include?("higher serial")
+      puts "⚠️  Remote serial changed underneath us. Re-fetching..."
+      # In a real generalized script, we might want to loop and retry here.
+      # For now, just exiting.
+    end
+    puts "STDOUT: #{stdout}"
+    puts "STDERR: #{stderr}"
+    exit 1
+  end
+  
+  # Optional: sleep to not hammer the API too hard
+  sleep 1
+end
+
+# Cleanup
+File.delete(temp_file) if File.exist?(temp_file)
+puts "\nDone! Pushed #{options[:iterations]} state versions."

--- a/scripts/push_multiple_states.rb
+++ b/scripts/push_multiple_states.rb
@@ -129,7 +129,14 @@ puts "Plan: Push #{options[:iterations]} new versions starting at serial #{curre
 temp_file = File.join(Dir.pwd, "temp_huge.tfstate")
 
 (1..options[:iterations]).each do |i|
-  next_serial = current_serial + i
+  # Fetch latest serial to handle remote updates/migrations
+  stdout, stderr, status = Open3.capture3("terraform", "state", "pull", :chdir => target_cwd)
+  if status.success?
+    remote_state = JSON.parse(stdout)
+    current_serial = remote_state["serial"]
+  end
+  
+  next_serial = current_serial + 1
   puts "\n--- Iteration #{i}/#{options[:iterations]} (Target Serial: #{next_serial}) ---"
 
   # Generate


### PR DESCRIPTION
I found that using this tool via `terraform state push` validated a lot of the contents of the state file against actual provider schemas. This PR brings the faked state closer in line with actual provider schemas and includes a script for generating sequences of large state files.